### PR TITLE
add npm `prepare` task

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,16 +22,16 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
 
--   OS: [e.g. iOS]
--   Browser [e.g. chrome, safari]
--   Version [e.g. 22]
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
 
--   Device: [e.g. iPhone6]
--   OS: [e.g. iOS8.1]
--   Browser [e.g. stock browser, safari]
--   Version [e.g. 22]
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,30 +1,30 @@
 name: main
 
 on:
-    push:
-        branches: [master, own]
-    pull_request:
-        branches: [master, own]
+  push:
+    branches: [master, own]
+  pull_request:
+    branches: [master, own]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-        strategy:
-            matrix:
-                node-version: [12.x, 14.x]
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
 
-        steps:
-            - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
-              with:
-                  node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-            - run: yarn
-            - run: yarn prettier --ignore-path .gitignore --check .
+      - run: yarn
+      - run: yarn prettier --ignore-path .gitignore --check .
 
-            - run: yarn build
-            # Need tests plz
-            # - run: yarn workspace @mckayla/electron-redux-e2e test
+      - run: yarn build
+      # Need tests plz
+      # - run: yarn workspace @mckayla/electron-redux-e2e test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,4 @@ jobs:
 
       - run: yarn build
       # Need tests plz
-      # - run: yarn workspace @mckayla/electron-redux-e2e test
+      # - run: yarn workspace @paulrosania/electron-redux-e2e test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 coverage/
 *.log
+Session.vim

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # electron-redux
 
-[![package version](https://img.shields.io/badge/@mckayla%2felectron--redux-v2.0.0-afbdf7.svg)](https://npmjs.com/package/@mckayla/electron-redux)
-![stability](https://img.shields.io/badge/stability-release-66f29a.svg)
-[![build status](https://github.com/partheseas/electron-redux/workflows/main/badge.svg)](https://github.com/partheseas/electron-redux/actions)
+[![package version](https://img.shields.io/badge/@paulrosania%2felectron--redux-v2.0.0-afbdf7.svg)](https://npmjs.com/package/@paulrosania/electron-redux)
+[![build status](https://github.com/paulrosania/electron-redux/workflows/main/badge.svg)](https://github.com/paulrosania/electron-redux/actions)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io)
 
 ![electron-redux data flow](https://cloud.githubusercontent.com/assets/307162/20675737/385ce59e-b585-11e6-947e-3867e77c783d.png)
@@ -12,18 +11,19 @@ in all of them.
 
 ```javascript
 // in the main process
-import { syncMain } from '@mckayla/electron-redux';
-const store = createStore(reducer, syncMain);
+import { syncMain } from '@paulrosania/electron-redux';
+const store = createStore(reducer, applyMiddleware(syncMain));
 ```
 
 ```javascript
 // in the renderer processes
-import { syncRenderer } from '@mckayla/electron-redux';
-const store = createStore(reducer, syncRenderer);
+import { syncRenderer, wrapRendererReducer } from '@paulrosania/electron-redux';
+const store = createStore(wrapRendererReducer(reducer), applyMiddleware(syncRenderer));
 ```
 
-That's it! Just add these enhancers to where you initialize your store. As long
-as your reducers are pure/deterministic (which they already should be) your state
+That's it! Just add each middleware to where you initialize your store, and wrap
+the renderer reducer so it can receive state from the main process. As long as
+your reducers are pure/deterministic (which they already should be) your state
 should be reproduced accurately across all of the processes.
 
 ## Actions
@@ -41,8 +41,6 @@ Actions **MUST** be serializable
 - Numbers
 - Booleans
 - Strings
-- Maps
-- Sets
 
 ### Local actions
 
@@ -62,12 +60,13 @@ const myLocalActionCreator = () => ({
 We also provide a utility function for this
 
 ```
-import { stopForwarding } from "@mckayla/electron-redux";
+import { stopForwarding } from "@paulrosania/electron-redux";
 dispatch(stopForwarding(action));
 ```
 
 ## Contributors
 
+- [McKayla Washburn](https://github.com/partheseas)
 - [Burkhard Reffeling](https://github.com/hardchor)
 - [Charlie Hess](https://github.com/CharlieHess)
 - [Roman Paradeev](https://github.com/sameoldmadness)

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ in all of them.
 
 ```javascript
 // in the main process
-import { syncMain } from "@mckayla/electron-redux";
+import { syncMain } from '@mckayla/electron-redux';
 const store = createStore(reducer, syncMain);
 ```
 
 ```javascript
 // in the renderer processes
-import { syncRenderer } from "@mckayla/electron-redux";
+import { syncRenderer } from '@mckayla/electron-redux';
 const store = createStore(reducer, syncRenderer);
 ```
 
@@ -36,13 +36,13 @@ be ignored and simply passed through to the next middleware.
 
 Actions **MUST** be serializable
 
--   Objects with enumerable properties
--   Arrays
--   Numbers
--   Booleans
--   Strings
--   Maps
--   Sets
+- Objects with enumerable properties
+- Arrays
+- Numbers
+- Booleans
+- Strings
+- Maps
+- Sets
 
 ### Local actions
 
@@ -51,11 +51,11 @@ played in the current thread, then you can set the scope meta property to local.
 
 ```javascript
 const myLocalActionCreator = () => ({
-	type: "MY_ACTION",
-	payload: 123,
-	meta: {
-		scope: "local", // only play the action locally
-	},
+  type: 'MY_ACTION',
+  payload: 123,
+  meta: {
+    scope: 'local', // only play the action locally
+  },
 });
 ```
 
@@ -68,6 +68,6 @@ dispatch(stopForwarding(action));
 
 ## Contributors
 
--   [Burkhard Reffeling](https://github.com/hardchor)
--   [Charlie Hess](https://github.com/CharlieHess)
--   [Roman Paradeev](https://github.com/sameoldmadness)
+- [Burkhard Reffeling](https://github.com/hardchor)
+- [Charlie Hess](https://github.com/CharlieHess)
+- [Roman Paradeev](https://github.com/sameoldmadness)

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@mckayla/electron-redux",
-	"version": "2.0.1",
-	"license": "MIT",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"description": "Keep your store in sync across processes",
-	"author": "McKayla Washburn",
-	"repository": "https://github.com/partheseas/electron-redux",
-	"bugs": "https://github.com/partheseas/electron-redux/issues",
-	"files": [
-		"dist/**"
-	],
-	"keywords": [
-		"electron",
-		"redux"
-	],
-	"engines": {
-		"node": ">= 12"
-	},
-	"dependencies": {
-		"debug": "^4.0.0",
-		"flux-standard-action": "^2.0.0"
-	},
-	"peerDependencies": {
-		"electron": ">=8.0.0",
-		"redux": ">=4.0.0"
-	},
-	"devDependencies": {
-		"@types/debug": "^4.1.5",
-		"electron": "^8.2.5",
-		"parcel": "^2.0.0-nightly.256",
-		"prettier": "^2.0.5",
-		"redux": "^4.0.5",
-		"typescript": "^3.8.3"
-	},
-	"scripts": {
-		"build": "parcel build src/index.ts",
-		"fmt": "prettier --ignore-path .gitignore --write .",
-		"prepare": "npm run build"
-	}
+  "name": "@mckayla/electron-redux",
+  "version": "2.0.1",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "Keep your store in sync across processes",
+  "author": "McKayla Washburn",
+  "repository": "https://github.com/partheseas/electron-redux",
+  "bugs": "https://github.com/partheseas/electron-redux/issues",
+  "files": [
+    "dist/**"
+  ],
+  "keywords": [
+    "electron",
+    "redux"
+  ],
+  "engines": {
+    "node": ">= 12"
+  },
+  "dependencies": {
+    "debug": "^4.0.0",
+    "flux-standard-action": "^2.0.0"
+  },
+  "peerDependencies": {
+    "electron": ">=8.0.0",
+    "redux": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.5",
+    "electron": "^8.2.5",
+    "parcel": "^2.0.0-nightly.256",
+    "prettier": "^2.0.5",
+    "redux": "^4.0.5",
+    "typescript": "^3.8.3"
+  },
+  "scripts": {
+    "build": "parcel build src/index.ts",
+    "fmt": "prettier --ignore-path .gitignore --write .",
+    "prepare": "npm run build"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	},
 	"scripts": {
 		"build": "parcel build src/index.ts",
-		"fmt": "prettier --ignore-path .gitignore --write ."
+		"fmt": "prettier --ignore-path .gitignore --write .",
+		"prepare": "npm run build"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@mckayla/electron-redux",
-  "version": "2.0.1",
+  "name": "@paulrosania/electron-redux",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Keep your store in sync across processes",
-  "author": "McKayla Washburn",
-  "repository": "https://github.com/partheseas/electron-redux",
-  "bugs": "https://github.com/partheseas/electron-redux/issues",
+  "author": "Paul Rosania",
+  "repository": "https://github.com/paulrosania/electron-redux",
+  "bugs": "https://github.com/paulrosania/electron-redux/issues",
   "files": [
     "dist/**"
   ],

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,4 @@
 module.exports = {
-	useTabs: true,
-	tabWidth: 4, // Necessary for prettier to align things, even though we use tabs
-	trailingComma: "all",
-	endOfLine: "lf",
+  trailingComma: 'es5',
+  singleQuote: true,
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,7 @@ const blacklist = [/^@@/, /^redux-form/];
 
 export const stopForwarding = (
   action: FluxStandardAction<string, unknown, ActionMeta>
-) => ({
+): FluxStandardAction<string, unknown, ActionMeta> => ({
   ...action,
   meta: {
     ...action.meta,
@@ -22,7 +22,6 @@ export const stopForwarding = (
 export const validateAction = (
   action: unknown
 ): action is FluxStandardAction<string, unknown, ActionMeta> => {
-  isFSA;
   if (!isFSA<string, unknown, ActionMeta>(action)) {
     log('Only flux-standard-actions will be forwarded', action);
     return false;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,38 +1,38 @@
-import debug from "debug";
-import { FluxStandardAction, isFSA } from "flux-standard-action";
+import debug from 'debug';
+import { FluxStandardAction, isFSA } from 'flux-standard-action';
 
 type ActionMeta = {
-	scope?: "local" | string;
+  scope?: 'local' | string;
 };
 
-const log = debug("mckayla.electron-redux.validation");
+const log = debug('mckayla.electron-redux.validation');
 
 const blacklist = [/^@@/, /^redux-form/];
 
 export const stopForwarding = (
-	action: FluxStandardAction<string, unknown, ActionMeta>,
+  action: FluxStandardAction<string, unknown, ActionMeta>
 ) => ({
-	...action,
-	meta: {
-		...action.meta,
-		scope: "local",
-	},
+  ...action,
+  meta: {
+    ...action.meta,
+    scope: 'local',
+  },
 });
 
 export const validateAction = (
-	action: unknown,
+  action: unknown
 ): action is FluxStandardAction<string, unknown, ActionMeta> => {
-	isFSA;
-	if (!isFSA<string, unknown, ActionMeta>(action)) {
-		log("Only flux-standard-actions will be forwarded", action);
-		return false;
-	}
+  isFSA;
+  if (!isFSA<string, unknown, ActionMeta>(action)) {
+    log('Only flux-standard-actions will be forwarded', action);
+    return false;
+  }
 
-	if (
-		action.meta?.scope === "local" ||
-		blacklist.some((rule) => rule.test(action.type))
-	)
-		return false;
+  if (
+    action.meta?.scope === 'local' ||
+    blacklist.some((rule) => rule.test(action.type))
+  )
+    return false;
 
-	return true;
+  return true;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./helpers";
-export * from "./middleware/syncMain";
-export * from "./middleware/syncRenderer";
+export * from './helpers';
+export * from './middleware/syncMain';
+export * from './middleware/syncRenderer';

--- a/src/middleware/syncMain.ts
+++ b/src/middleware/syncMain.ts
@@ -1,69 +1,69 @@
-import debug from "debug";
-import { ipcMain, webContents } from "electron";
+import debug from 'debug';
+import { ipcMain, webContents } from 'electron';
 import {
-	Action,
-	applyMiddleware,
-	Middleware,
-	StoreCreator,
-	StoreEnhancer,
-} from "redux";
+  Action,
+  applyMiddleware,
+  Middleware,
+  StoreCreator,
+  StoreEnhancer,
+} from 'redux';
 
-const log = debug("mckayla.electron-redux.sync");
+const log = debug('mckayla.electron-redux.sync');
 
-import { stopForwarding, validateAction } from "../helpers";
+import { stopForwarding, validateAction } from '../helpers';
 
 let previouslyInitialzed: Error;
 
 const freeze = (_: string, value: unknown): unknown => {
-	if (value instanceof Map) {
-		const obj = Object.fromEntries(value);
-		obj.__hydrate_type = "__hydrate_map";
-		return obj;
-	} else if (value instanceof Set) {
-		return {
-			__hydrate_type: "__hydrate_set",
-			items: Array.from(value),
-		};
-	}
+  if (value instanceof Map) {
+    const obj = Object.fromEntries(value);
+    obj.__hydrate_type = '__hydrate_map';
+    return obj;
+  } else if (value instanceof Set) {
+    return {
+      __hydrate_type: '__hydrate_set',
+      items: Array.from(value),
+    };
+  }
 
-	return value;
+  return value;
 };
 
 const middleware: Middleware = (store) => {
-	ipcMain.handle("mckayla.electron-redux.FETCH_STATE", async () => {
-		return JSON.stringify(store.getState(), freeze);
-	});
+  ipcMain.handle('mckayla.electron-redux.FETCH_STATE', async () => {
+    return JSON.stringify(store.getState(), freeze);
+  });
 
-	ipcMain.on("mckayla.electron-redux.ACTION", (event, action: Action) => {
-		store.dispatch(stopForwarding(action));
-	});
+  ipcMain.on('mckayla.electron-redux.ACTION', (event, action: Action) => {
+    store.dispatch(stopForwarding(action));
+  });
 
-	// We are intentionally not actually throwing the error here, we just
-	// want to capture the call stack for debugging.
-	previouslyInitialzed = new Error("Previously attached to a store at");
+  // We are intentionally not actually throwing the error here, we just
+  // want to capture the call stack for debugging.
+  previouslyInitialzed = new Error('Previously attached to a store at');
 
-	return (next) => (action) => {
-		if (validateAction(action)) {
-			log("forwarding following action to renderers");
-			webContents.getAllWebContents().forEach((contents) => {
-				contents.send("mckayla.electron-redux.ACTION", action);
-			});
-		}
+  return (next) => (action) => {
+    if (validateAction(action)) {
+      log('forwarding following action to renderers');
+      webContents.getAllWebContents().forEach((contents) => {
+        contents.send('mckayla.electron-redux.ACTION', action);
+      });
+    }
 
-		log("action:", action);
-		return next(action);
-	};
+    log('action:', action);
+    return next(action);
+  };
 };
 
 export const syncMain: StoreEnhancer = (createStore: StoreCreator) => {
-	if (previouslyInitialzed) {
-		console.error(
-			new Error("electron-redux has already been attached to a store"),
-		);
-		console.error(previouslyInitialzed);
-	}
+  if (previouslyInitialzed) {
+    console.error(
+      new Error('electron-redux has already been attached to a store')
+    );
+    console.error(previouslyInitialzed);
+  }
 
-	return (reducer, state) => {
-		return createStore(reducer, state, applyMiddleware(middleware));
-	};
+  return (reducer, state) => {
+    return createStore(reducer, state, applyMiddleware(middleware));
+  };
 };

--- a/src/middleware/syncMain.ts
+++ b/src/middleware/syncMain.ts
@@ -1,69 +1,34 @@
-import debug from 'debug';
 import { ipcMain, webContents } from 'electron';
-import {
-  Action,
-  applyMiddleware,
-  Middleware,
-  StoreCreator,
-  StoreEnhancer,
-} from 'redux';
-
-const log = debug('mckayla.electron-redux.sync');
+import { Action, Middleware } from 'redux';
+import { findRemoteAction } from '../remoteActions';
 
 import { stopForwarding, validateAction } from '../helpers';
 
-let previouslyInitialzed: Error;
-
-const freeze = (_: string, value: unknown): unknown => {
-  if (value instanceof Map) {
-    const obj = Object.fromEntries(value);
-    obj.__hydrate_type = '__hydrate_map';
-    return obj;
-  } else if (value instanceof Set) {
-    return {
-      __hydrate_type: '__hydrate_set',
-      items: Array.from(value),
-    };
-  }
-
-  return value;
-};
-
-const middleware: Middleware = (store) => {
+export const syncMain: Middleware = ({ dispatch, getState }) => {
   ipcMain.handle('mckayla.electron-redux.FETCH_STATE', async () => {
-    return JSON.stringify(store.getState(), freeze);
+    return JSON.stringify(getState());
   });
 
   ipcMain.on('mckayla.electron-redux.ACTION', (event, action: Action) => {
-    store.dispatch(stopForwarding(action));
+    dispatch(stopForwarding(action));
   });
 
-  // We are intentionally not actually throwing the error here, we just
-  // want to capture the call stack for debugging.
-  previouslyInitialzed = new Error('Previously attached to a store at');
+  ipcMain.on(
+    'mckayla.electron-redux.CREATE_ACTION',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (event, action: { type: string; args: any[] }) => {
+      const localAction = findRemoteAction(action.type)?.(...action.args);
+      dispatch(localAction);
+    }
+  );
 
-  return (next) => (action) => {
+  return (next) => <A extends Action>(action: A): A => {
     if (validateAction(action)) {
-      log('forwarding following action to renderers');
       webContents.getAllWebContents().forEach((contents) => {
         contents.send('mckayla.electron-redux.ACTION', action);
       });
     }
 
-    log('action:', action);
     return next(action);
-  };
-};
-
-export const syncMain: StoreEnhancer = (createStore: StoreCreator) => {
-  if (previouslyInitialzed) {
-    console.error(
-      new Error('electron-redux has already been attached to a store')
-    );
-    console.error(previouslyInitialzed);
-  }
-
-  return (reducer, state) => {
-    return createStore(reducer, state, applyMiddleware(middleware));
   };
 };

--- a/src/middleware/syncRenderer.ts
+++ b/src/middleware/syncRenderer.ts
@@ -1,107 +1,105 @@
-import debug from "debug";
-import { ipcRenderer } from "electron";
+import debug from 'debug';
+import { ipcRenderer } from 'electron';
 import {
-	Action,
-	applyMiddleware,
-	Middleware,
-	Reducer,
-	StoreCreator,
-	StoreEnhancer,
-} from "redux";
-import { stopForwarding, validateAction } from "../helpers";
+  Action,
+  applyMiddleware,
+  Middleware,
+  Reducer,
+  StoreCreator,
+  StoreEnhancer,
+} from 'redux';
+import { stopForwarding, validateAction } from '../helpers';
 
-const log = debug("mckayla.electron-redux.sync");
+const log = debug('mckayla.electron-redux.sync');
 
 const hydrate = (_: string, value: any) => {
-	if (value?.__hydrate_type === "__hydrate_map") {
-		return new Map(
-			Object.entries(value).filter(([key]) => key !== "__hydrate_type"),
-		);
-	} else if (value?.__hydrate_type === "__hydrate_set") {
-		return new Set(value.items);
-	}
+  if (value?.__hydrate_type === '__hydrate_map') {
+    return new Map(
+      Object.entries(value).filter(([key]) => key !== '__hydrate_type')
+    );
+  } else if (value?.__hydrate_type === '__hydrate_set') {
+    return new Set(value.items);
+  }
 
-	return value;
+  return value;
 };
 
 export async function getRendererState(callback: (state) => void) {
-	const state = await ipcRenderer.invoke(
-		"mckayla.electron-redux.FETCH_STATE",
-	);
+  const state = await ipcRenderer.invoke('mckayla.electron-redux.FETCH_STATE');
 
-	// TODO: I don't think this is the right error handling anymore
-	if (typeof state !== "string") {
-		throw new Error(
-			"No Redux store found in main process. Did you apply the middleware?",
-		);
-	}
+  // TODO: I don't think this is the right error handling anymore
+  if (typeof state !== 'string') {
+    throw new Error(
+      'No Redux store found in main process. Did you apply the middleware?'
+    );
+  }
 
-	// I just don't like the ().then() syntax
-	// TODO: Copy and paste shrug emoji
-	return callback(JSON.parse(state, hydrate));
+  // I just don't like the ().then() syntax
+  // TODO: Copy and paste shrug emoji
+  return callback(JSON.parse(state, hydrate));
 }
 
 const replaceState = <S>(state: S) => ({
-	type: "mckayla.electron-redux.REPLACE_STATE" as const,
-	payload: state,
-	meta: { scope: "local" },
+  type: 'mckayla.electron-redux.REPLACE_STATE' as const,
+  payload: state,
+  meta: { scope: 'local' },
 });
 
 type InternalAction = ReturnType<typeof replaceState>;
 
 const wrapReducer = (reducer: Reducer) => <S, A extends Action>(
-	state: S,
-	action: InternalAction | A,
+  state: S,
+  action: InternalAction | A
 ) => {
-	switch (action.type) {
-		case "mckayla.electron-redux.REPLACE_STATE":
-			return (action as InternalAction).payload;
-		default:
-			return reducer(state, action);
-	}
+  switch (action.type) {
+    case 'mckayla.electron-redux.REPLACE_STATE':
+      return (action as InternalAction).payload;
+    default:
+      return reducer(state, action);
+  }
 };
 
 const middleware: Middleware = (store) => {
-	ipcRenderer.on("mckayla.electron-redux.ACTION", (_, action: Action) => {
-		store.dispatch(stopForwarding(action));
-	});
+  ipcRenderer.on('mckayla.electron-redux.ACTION', (_, action: Action) => {
+    store.dispatch(stopForwarding(action));
+  });
 
-	return (next) => (action) => {
-		if (validateAction(action)) {
-			// TODO: We need a way to send actions from one renderer to another
-			log("forwarding following action to main");
-			ipcRenderer.send("mckayla.electron-redux.ACTION", action);
-		}
+  return (next) => (action) => {
+    if (validateAction(action)) {
+      // TODO: We need a way to send actions from one renderer to another
+      log('forwarding following action to main');
+      ipcRenderer.send('mckayla.electron-redux.ACTION', action);
+    }
 
-		log("action:", action);
-		return next(action);
-	};
+    log('action:', action);
+    return next(action);
+  };
 };
 
 export const syncRenderer: StoreEnhancer = (createStore: StoreCreator) => {
-	return (reducer, state) => {
-		const store = createStore(
-			wrapReducer(reducer),
-			state,
-			applyMiddleware(middleware),
-		);
+  return (reducer, state) => {
+    const store = createStore(
+      wrapReducer(reducer),
+      state,
+      applyMiddleware(middleware)
+    );
 
-		// This is the reason we need to be an enhancer, rather than a middleware.
-		// We use this (along with the wrapReducer function above) to dispatch an
-		// action that initializes the store without needing to fetch it synchronously.
+    // This is the reason we need to be an enhancer, rather than a middleware.
+    // We use this (along with the wrapReducer function above) to dispatch an
+    // action that initializes the store without needing to fetch it synchronously.
 
-		// Also relevant, this is internally implemented using promises. It would be really
-		// cool to use async/await syntax but we need to return a Store, not a Promise.
-		getRendererState((state) => {
-			store.dispatch(replaceState(state));
-		});
+    // Also relevant, this is internally implemented using promises. It would be really
+    // cool to use async/await syntax but we need to return a Store, not a Promise.
+    getRendererState((state) => {
+      store.dispatch(replaceState(state));
+    });
 
-		// TypeScript is fucking dumb. If you return the call to createStore
-		// immediately it's fine, but even assigning it to a constant and returning
-		// will make it freak out.
-		return store;
-		// Even though this line is unreachable, it fixes the type signature????
-		// What the actual fuck TypeScript?
-		return (store as unknown) as any;
-	};
+    // TypeScript is fucking dumb. If you return the call to createStore
+    // immediately it's fine, but even assigning it to a constant and returning
+    // will make it freak out.
+    return store;
+    // Even though this line is unreachable, it fixes the type signature????
+    // What the actual fuck TypeScript?
+    return (store as unknown) as any;
+  };
 };

--- a/src/middleware/syncRenderer.ts
+++ b/src/middleware/syncRenderer.ts
@@ -1,30 +1,8 @@
-import debug from 'debug';
 import { ipcRenderer } from 'electron';
-import {
-  Action,
-  applyMiddleware,
-  Middleware,
-  Reducer,
-  StoreCreator,
-  StoreEnhancer,
-} from 'redux';
+import { Action, AnyAction, Middleware, Reducer } from 'redux';
 import { stopForwarding, validateAction } from '../helpers';
 
-const log = debug('mckayla.electron-redux.sync');
-
-const hydrate = (_: string, value: any) => {
-  if (value?.__hydrate_type === '__hydrate_map') {
-    return new Map(
-      Object.entries(value).filter(([key]) => key !== '__hydrate_type')
-    );
-  } else if (value?.__hydrate_type === '__hydrate_set') {
-    return new Set(value.items);
-  }
-
-  return value;
-};
-
-export async function getRendererState(callback: (state) => void) {
+export async function getRendererState<S>(): Promise<S> {
   const state = await ipcRenderer.invoke('mckayla.electron-redux.FETCH_STATE');
 
   // TODO: I don't think this is the right error handling anymore
@@ -34,72 +12,52 @@ export async function getRendererState(callback: (state) => void) {
     );
   }
 
-  // I just don't like the ().then() syntax
-  // TODO: Copy and paste shrug emoji
-  return callback(JSON.parse(state, hydrate));
+  return JSON.parse(state);
 }
 
-const replaceState = <S>(state: S) => ({
-  type: 'mckayla.electron-redux.REPLACE_STATE' as const,
-  payload: state,
-  meta: { scope: 'local' },
-});
+interface ReplaceStateAction<S> extends Action {
+  type: 'mckayla.electron-redux.REPLACE_STATE';
+  payload: S;
+  meta: { scope: 'local' };
+}
 
-type InternalAction = ReturnType<typeof replaceState>;
+function replaceState<S>(state: S): ReplaceStateAction<S> {
+  return {
+    type: 'mckayla.electron-redux.REPLACE_STATE',
+    payload: state,
+    meta: { scope: 'local' },
+  };
+}
 
-const wrapReducer = (reducer: Reducer) => <S, A extends Action>(
-  state: S,
-  action: InternalAction | A
-) => {
-  switch (action.type) {
-    case 'mckayla.electron-redux.REPLACE_STATE':
-      return (action as InternalAction).payload;
-    default:
-      return reducer(state, action);
-  }
-};
+export function wrapRendererReducer(reducer: Reducer): Reducer {
+  return <S, A extends Action>(
+    state: S,
+    action: A | ReplaceStateAction<S>
+  ): S => {
+    switch (action.type) {
+      case 'mckayla.electron-redux.REPLACE_STATE':
+        return (action as ReplaceStateAction<S>).payload;
+      default:
+        return reducer(state, action);
+    }
+  };
+}
 
-const middleware: Middleware = (store) => {
-  ipcRenderer.on('mckayla.electron-redux.ACTION', (_, action: Action) => {
-    store.dispatch(stopForwarding(action));
+export const syncRenderer: Middleware = ({ dispatch }) => {
+  getRendererState().then((state) => {
+    dispatch(replaceState(state));
   });
 
-  return (next) => (action) => {
+  ipcRenderer.on('mckayla.electron-redux.ACTION', (_, action: Action) => {
+    dispatch(stopForwarding(action));
+  });
+
+  return (next) => <A extends AnyAction>(action: A): A => {
     if (validateAction(action)) {
       // TODO: We need a way to send actions from one renderer to another
-      log('forwarding following action to main');
       ipcRenderer.send('mckayla.electron-redux.ACTION', action);
     }
 
-    log('action:', action);
     return next(action);
-  };
-};
-
-export const syncRenderer: StoreEnhancer = (createStore: StoreCreator) => {
-  return (reducer, state) => {
-    const store = createStore(
-      wrapReducer(reducer),
-      state,
-      applyMiddleware(middleware)
-    );
-
-    // This is the reason we need to be an enhancer, rather than a middleware.
-    // We use this (along with the wrapReducer function above) to dispatch an
-    // action that initializes the store without needing to fetch it synchronously.
-
-    // Also relevant, this is internally implemented using promises. It would be really
-    // cool to use async/await syntax but we need to return a Store, not a Promise.
-    getRendererState((state) => {
-      store.dispatch(replaceState(state));
-    });
-
-    // TypeScript is fucking dumb. If you return the call to createStore
-    // immediately it's fine, but even assigning it to a constant and returning
-    // will make it freak out.
-    return store;
-    // Even though this line is unreachable, it fixes the type signature????
-    // What the actual fuck TypeScript?
-    return (store as unknown) as any;
   };
 };

--- a/src/remoteActions.ts
+++ b/src/remoteActions.ts
@@ -1,0 +1,35 @@
+import { ipcRenderer } from 'electron';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RemoteActionCreator = (...args: any[]) => any;
+
+const remoteActionCreators: {
+  [index: string]: RemoteActionCreator;
+} = {};
+
+export function findRemoteAction(
+  type: string
+): RemoteActionCreator | undefined {
+  return remoteActionCreators[type];
+}
+
+export function createRemoteAction(
+  type: string,
+  creator: RemoteActionCreator
+): RemoteActionCreator {
+  const isRenderer = process && process.type === 'renderer';
+
+  if (isRenderer) {
+    return (...args) => {
+      return (): void => {
+        ipcRenderer.send('mckayla.electron-redux.CREATE_ACTION', {
+          type: type,
+          args,
+        });
+      };
+    };
+  } else {
+    remoteActionCreators[type] = creator;
+    return (...args): ReturnType<RemoteActionCreator> => creator(...args);
+  }
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>electron-redux</title>
-	</head>
-	<body style="background-color: white;">
-		<h1>electron-redux</h1>
-		<script type="application/javascript" src="renderer.js"></script>
-	</body>
+  <head>
+    <title>electron-redux</title>
+  </head>
+  <body style="background-color: white;">
+    <h1>electron-redux</h1>
+    <script type="application/javascript" src="renderer.js"></script>
+  </body>
 </html>

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,71 +1,71 @@
-const log = require("debug")("mckayla.electron-redux.test");
-const { app, BrowserWindow } = require("electron");
-const path = require("path");
-const url = require("url");
+const log = require('debug')('mckayla.electron-redux.test');
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const url = require('url');
 
-const { increment, store } = require("./store/main");
+const { increment, store } = require('./store/main');
 
 store.subscribe(() => {
-	log(store.getState());
+  log(store.getState());
 });
 
 setInterval(() => {
-	store.dispatch(increment());
+  store.dispatch(increment());
 }, 1000);
 
 const views = [];
 
 const createWindow = () => {
-	// Create the browser window.
-	const view = new BrowserWindow({
-		width: 1380,
-		height: 830,
-		webPreferences: {
-			nodeIntegration: true,
-		},
-	});
+  // Create the browser window.
+  const view = new BrowserWindow({
+    width: 1380,
+    height: 830,
+    webPreferences: {
+      nodeIntegration: true,
+    },
+  });
 
-	// and load the index.html of the app.
-	view.loadURL(
-		url.format({
-			pathname: path.join(__dirname, "index.html"),
-			protocol: "file:",
-			slashes: true,
-		}),
-	);
+  // and load the index.html of the app.
+  view.loadURL(
+    url.format({
+      pathname: path.join(__dirname, 'index.html'),
+      protocol: 'file:',
+      slashes: true,
+    })
+  );
 
-	// Open the DevTools.
-	view.webContents.openDevTools();
+  // Open the DevTools.
+  view.webContents.openDevTools();
 
-	// Emitted when the window is closed.
-	view.on("closed", () => {
-		// Just close both if we close one
-		app.quit();
-	});
+  // Emitted when the window is closed.
+  view.on('closed', () => {
+    // Just close both if we close one
+    app.quit();
+  });
 
-	views.push(view);
+  views.push(view);
 };
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on("ready", () => {
-	// On OS X it's common to re-create a window in the app when the
-	// dock icon is clicked and there are no other windows open.
-	while (views.length < 2) {
-		createWindow();
-	}
+app.on('ready', () => {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  while (views.length < 2) {
+    createWindow();
+  }
 });
 
 // Quit when all windows are closed.
-app.on("window-all-closed", () => {
-	app.quit();
+app.on('window-all-closed', () => {
+  app.quit();
 });
 
-app.on("activate", () => {
-	// On OS X it's common to re-create a window in the app when the
-	// dock icon is clicked and there are no other windows open.
-	while (views.length < 2) {
-		createWindow();
-	}
+app.on('activate', () => {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  while (views.length < 2) {
+    createWindow();
+  }
 });

--- a/tests/renderer.js
+++ b/tests/renderer.js
@@ -1,22 +1,22 @@
-const log = require("debug")("mckayla.electron-redux.test");
-const { decrement, increment, store } = require("./store/renderer");
+const log = require('debug')('mckayla.electron-redux.test');
+const { decrement, increment, store } = require('./store/renderer');
 
 store.subscribe(() => {
-	const state = store.getState();
-	log(state);
-	d.innerHTML = state.count;
+  const state = store.getState();
+  log(state);
+  d.innerHTML = state.count;
 });
 
-const d = document.createElement("h2");
+const d = document.createElement('h2');
 d.innerHTML = store.getState().count;
 document.body.appendChild(d);
 
-const b = document.createElement("button");
-b.innerHTML = "-";
-b.addEventListener("click", () => store.dispatch(decrement()));
+const b = document.createElement('button');
+b.innerHTML = '-';
+b.addEventListener('click', () => store.dispatch(decrement()));
 document.body.appendChild(b);
 
-const i = document.createElement("button");
-i.innerHTML = "+";
-i.addEventListener("click", () => store.dispatch(increment()));
+const i = document.createElement('button');
+i.innerHTML = '+';
+i.addEventListener('click', () => store.dispatch(increment()));
 document.body.appendChild(i);

--- a/tests/store/common.js
+++ b/tests/store/common.js
@@ -1,5 +1,5 @@
 const init = () => ({
-	count: 0,
+  count: 0,
 });
 
 // type Action =
@@ -8,27 +8,27 @@ const init = () => ({
 // 	| ReturnType<typeof adjustBy>;
 
 exports.increment = () => ({
-	type: "mckayla.electron-redux.INCREMENT",
+  type: 'mckayla.electron-redux.INCREMENT',
 });
 
 exports.decrement = () => ({
-	type: "mckayla.electron-redux.DECREMENT",
+  type: 'mckayla.electron-redux.DECREMENT',
 });
 
 exports.adjustBy = (amount) => ({
-	type: "mckayla.electron-redux.ADJUST_BY",
-	payload: { amount },
+  type: 'mckayla.electron-redux.ADJUST_BY',
+  payload: { amount },
 });
 
 exports.reducer = (state = init(), action) => {
-	switch (action.type) {
-		case "mckayla.electron-redux.INCREMENT":
-			return { count: state.count + 1 };
-		case "mckayla.electron-redux.DECREMENT":
-			return { count: state.count - 1 };
-		case "mckayla.electron-redux.ADJUST_BY":
-			return { count: state.count + action.payload.amount };
-		default:
-			return state;
-	}
+  switch (action.type) {
+    case 'mckayla.electron-redux.INCREMENT':
+      return { count: state.count + 1 };
+    case 'mckayla.electron-redux.DECREMENT':
+      return { count: state.count - 1 };
+    case 'mckayla.electron-redux.ADJUST_BY':
+      return { count: state.count + action.payload.amount };
+    default:
+      return state;
+  }
 };

--- a/tests/store/main.js
+++ b/tests/store/main.js
@@ -1,7 +1,7 @@
-const { syncMain } = require("../..");
-const redux = require("redux");
+const { syncMain } = require('../..');
+const redux = require('redux');
 
-const { increment, reducer } = require("./common");
+const { increment, reducer } = require('./common');
 
 const store = redux.createStore(reducer, syncMain);
 

--- a/tests/store/renderer.js
+++ b/tests/store/renderer.js
@@ -1,7 +1,7 @@
-const { syncRenderer } = require("../..");
-const redux = require("redux");
+const { syncRenderer } = require('../..');
+const redux = require('redux');
 
-const { decrement, increment, reducer } = require("./common");
+const { decrement, increment, reducer } = require('./common');
 
 const store = redux.createStore(reducer, syncRenderer);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
-	"target": "esnext",
-	"compilerOptions": {
-		"declaration": true,
-		"lib": ["dom", "esnext"],
-		"outDir": "dist"
-	}
+  "target": "esnext",
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["dom", "esnext"],
+    "outDir": "dist"
+  }
 }


### PR DESCRIPTION
Amazing fork! I love how clean and simple it is.

I wanted to use your TypeScript types, which aren't in your npm package yet, so I wanted to install directly from git for now while I play with your fork. I needed to add a `prepare` step so that a git-based `npm install` would build correctly. This should enable `npm install mckayla/electron-redux`, if you like! :)